### PR TITLE
fix: ensure the workflow ran before accessing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - **context**: proper parsing of optional values from environment
-- **context**: rely on github exposed environement variables
+- **context**: rely on github exposed environment variables
 - **inputs**: default ref is `{{ github.ref }}`
 
 ### 📖 Documentation

--- a/need_checks/action.py
+++ b/need_checks/action.py
@@ -125,6 +125,8 @@ def run(ctx: Context):
             workflow_id=ctx.inputs.workflow,
             head_sha=ref["object"]["sha"],
         )
+        if not runs.workflow_runs:
+            raise errors.RequirementsNotMet("The workflow was not run on the commit")
         last_run = cast(WorkflowRun, runs.workflow_runs[-1])
         check_suite = last_run["check_suite_id"]
 


### PR DESCRIPTION
If the CI workflow never ran on the main branch, `runs.workflow_runs` is empty and `runs.workflow_runs[-1]` raises an exception:

```text
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/lib/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/app/lib/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/need_checks/action.py", line 153, in __main__
    run(ctx)
  File "/app/need_checks/action.py", line 128, in run
    last_run = cast(WorkflowRun, runs.workflow_runs[-1])
                                 ~~~~~~~~~~~~~~~~~~^^^^
  File "/app/lib/fastcore/foundation.py", line 112, in __getitem__
    def __getitem__(self, idx): return self._get(idx) if is_indexer(idx) else L(self._get(idx), use_list=None)
                                       ^^^^^^^^^^^^^^
  File "/app/lib/fastcore/foundation.py", line 116, in _get
    if is_indexer(i) or isinstance(i,slice): return getattr(self.items,'iloc',self.items)[i]
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
```